### PR TITLE
change instances of :lon to :lng to conform with google maps conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Dependency
 [](dependency)
 ```clojure
-[rowtr/google-maps "3.18.6"] ;; latest release
+[rowtr/google-maps "3.18.8"] ;; latest release
 ```
 [](/dependency)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Dependency
 [](dependency)
 ```clojure
-[hoplon/google-maps "3.18.0-1"] ;; latest release
+[rowtr/google-maps "3.18.6"] ;; latest release
 ```
 [](/dependency)
 

--- a/boot.properties
+++ b/boot.properties
@@ -1,4 +1,0 @@
-#https://github.com/boot-clj/boot
-#Sat Sep 19 11:31:37 BRT 2015
-BOOT_CLOJURE_VERSION=1.7.0
-BOOT_VERSION=2.2.0

--- a/build.boot
+++ b/build.boot
@@ -1,21 +1,25 @@
 (set-env!
   :resource-paths #{"src"}
-  :dependencies '[[adzerk/bootlaces           "0.1.9"         :scope "test"]
-                  [tailrecursion/boot-hoplon  "0.1.0"         :scope "test"]
-                  [tailrecursion/hoplon       "6.0.0-SNAPSHOT"]
-                  [cljsjs/google-maps         "3.18-0"]
-                  [hoplon/google-loader       "0.1.0"]])
+  :dependencies '[[adzerk/bootlaces           "0.1.9"           :scope "test"]
+                  [hoplon/boot-hoplon         "0.1.9"           :scope "test"]
+                  [hoplon/hoplon              "6.0.0-alpha14"]
+                  [adzerk/env                 "0.2.0"]
+                  [adzerk/cljs-console        "0.1.1"]
+                  [cljsjs/google-maps         "3.18-1"]
+                  [hoplon/google-loader       "0.2.0"]])
 
 (require '[adzerk.bootlaces :refer :all]
-         '[tailrecursion.boot-hoplon :refer :all])
+         '[hoplon.boot-hoplon :refer :all])
 
-(def +version+ "3.18.0")
+(def +version+ "3.18.4")
 
 (task-options!
- pom  {:project     'hoplon/google-maps
-       :version     +version+
-       :description "hoplon google maps component"
-       :url         "https://developers.google.com/maps/documentation/javascript/"
-       :scm         {:url "https://github.com/hoplon/google-maps"}
-       :license     {"" ""}})
+ hoplon {:refers      '[adzerk.cljs-console]}
+ push   {:repo        "clojars-upload"}
+ pom    {:project     'rowtr/google-maps
+         :version     +version+
+         :description "hoplon google maps component"
+         :url         "https://developers.google.com/maps/documentation/javascript/"
+         :scm         {:url "https://github.com/hoplon/google-maps"}
+         :license     {"" ""}})
 

--- a/build.boot
+++ b/build.boot
@@ -1,19 +1,18 @@
 (set-env!
   :resource-paths #{"src"}
   :dependencies '[[adzerk/bootlaces           "0.1.9"           :scope "test"]
-                  [hoplon/boot-hoplon         "0.1.9"           :scope "test"]
-                  [hoplon/hoplon              "6.0.0-alpha14"]
-                  [adzerk/env                 "0.2.0"]
+                  [hoplon/hoplon              "7.2.0"]
+                  [adzerk/env                 "0.4.0"]
                   [adzerk/cljs-console        "0.1.1"]
                   [cljsjs/google-maps         "3.18-1"]
                   [hoplon/google-loader       "0.2.0"]])
+
 (require '[adzerk.bootlaces :refer :all]
          '[hoplon.boot-hoplon :refer :all])
 
-(def +version+ "3.18.4")
+(def +version+ "3.18.6")
 
 (task-options!
- hoplon {:refers      '[adzerk.cljs-console]}
  push   {:repo        "clojars-upload"}
  pom    {:project     'rowtr/google-maps
          :version     +version+

--- a/build.boot
+++ b/build.boot
@@ -1,16 +1,17 @@
 (set-env!
   :resource-paths #{"src"}
   :dependencies '[[adzerk/bootlaces           "0.1.9"           :scope "test"]
-                  [hoplon/hoplon              "7.2.0"]
+;                 [hoplon/hoplon              "7.2.0"           :scope "test"]
                   [adzerk/env                 "0.4.0"]
                   [adzerk/cljs-console        "0.1.1"]
                   [cljsjs/google-maps         "3.18-1"]
                   [hoplon/google-loader       "0.2.0"]])
 
 (require '[adzerk.bootlaces :refer :all]
-         '[hoplon.boot-hoplon :refer :all])
+        ;'[hoplon.boot-hoplon :refer :all]
+         )
 
-(def +version+ "3.18.6")
+(def +version+ "3.18.8")
 
 (task-options!
  push   {:repo        "clojars-upload"}

--- a/build.boot
+++ b/build.boot
@@ -9,7 +9,7 @@
 (require '[adzerk.bootlaces :refer :all]
          '[hoplon.boot-hoplon :refer :all])
 
-(def +version+ "3.18.0-1")
+(def +version+ "3.18.0-2")
 
 (task-options!
  pom  {:project     'hoplon/google-maps

--- a/src/hoplon/google/jsapi/maps.cljs
+++ b/src/hoplon/google/jsapi/maps.cljs
@@ -178,8 +178,7 @@
 
               ;;;;;;; Circles
               (cell-doseq [[i {:keys [opts] :as circ}] (cell= (indexed circles))]
-                (let [circle (Circle. (clj->js {}))
-                      _      (cell= (.log js/console (clj->js circ)))]
+                (let [circle    (Circle. (clj->js {}))]
                   (doseq [x cir-callbacks]
                     (let [evt (rm-pfx (name (key x)))
                           fun (val x)
@@ -187,7 +186,7 @@
                       (.addListener Event circle evt wrp)))
                   (cell=
                     ((~(partial delay-until visible?)
-                      #(let [map  imap
+                      #(let [map  (when (-> opts :center) imap)
                              opt  (clj->js (merge {} opts {:map map}))]
                       (.setOptions circle opt)))))))
 

--- a/src/hoplon/google/jsapi/maps.cljs
+++ b/src/hoplon/google/jsapi/maps.cljs
@@ -2,7 +2,9 @@
   (:refer-clojure :exclude [clj->js])
   (:require
     [clojure.string :as string]
-    [hoplon.google.jsapi.loader :refer [queued ensure-api]]))
+    [javelin.core   :as j       :refer [defc defc= cell= cell cell-doseq with-let]]
+    [hoplon.core    :as h       :refer [div defelem]]
+    [hoplon.google.jsapi.loader :refer [queued ensure-api api-key]]))
 
 (defn clj->js
   "Recursively transforms ClojureScript maps into Javascript objects,
@@ -19,7 +21,7 @@
     :else x))
 
 (defc  maps-version "3")
-(defc  maps-options {:other_params "libraries=geometry"})
+(defc=  maps-options {:other_params (str "libraries=geometry" (when api-key (str "&key=" api-key)))})
 
 (def ensure-maps
   (queued
@@ -32,14 +34,17 @@
 (defn- indexed [coll] (map-indexed vector coll))
 
 (defn delay-until [ready? f & args]
-  #(cell= (when ready? (~(memoize (fn [] (or (apply f args) ::ok)))))))
+  (let [doit    (memoize #(or (apply f args) ::ok))]
+    #(cell= (when ready? (doit)))))
 
 (defn starts-with? [string prefix]
   (= 0 (.lastIndexOf string prefix 0)))
 
-(defn visible? [elem]
+(defn visible? [elem & [msg]]
   (with-let [c (cell nil)]
-    (with-interval 100 (reset! c (.is (js/jQuery elem) ":visible")))))
+    (h/with-interval 100
+      (reset! c (.is (js/jQuery elem) ":visible"))
+      (when (and msg @c) (.log js/console msg)))))
 
 (defn decode-path [coded]
   (let [maps (.. js/google -maps)
@@ -98,6 +103,7 @@
           fit-pins      (:hoplon.google.jsapi.maps/fit-pins attr)
           markers       (:hoplon.google.jsapi.maps/markers attr)
           polylines     (:hoplon.google.jsapi.maps/polylines attr)
+          circles       (:hoplon.google.jsapi.maps/circles attr)
           polygons      (:hoplon.google.jsapi.maps/polygons attr)
           controls      (:hoplon.google.jsapi.maps/controls attr)
           mkfilter      #(fn [[x _]]
@@ -106,6 +112,7 @@
                                (starts-with? nm %))))
           layers        (filter (mkfilter "layer-") attr)
           map-callbacks (filter (mkfilter "map-") attr)
+          cir-callbacks (filter (mkfilter "cir-") attr)
           pln-callbacks (filter (mkfilter "polyline-") attr)
           pgn-callbacks (filter (mkfilter "polygon-") attr)
           pin-callbacks (filter (mkfilter "marker-") attr)
@@ -113,59 +120,48 @@
       (ensure-maps
         (delay-until visible?
           (fn []
-            (let [control-positions {:TL
-                                     google.maps.ControlPosition.TOP_LEFT,
-                                     :BC
-                                     google.maps.ControlPosition.BOTTOM_CENTER,
-                                     :LC
-                                     google.maps.ControlPosition.LEFT_CENTER,
-                                     :BL
-                                     google.maps.ControlPosition.BOTTOM_LEFT,
-                                     :LB
-                                     google.maps.ControlPosition.LEFT_BOTTOM,
-                                     :BR
-                                     google.maps.ControlPosition.BOTTOM_RIGHT,
-                                     :TR
-                                     google.maps.ControlPosition.TOP_RIGHT,
-                                     :LT
-                                     google.maps.ControlPosition.LEFT_TOP,
-                                     :TC
-                                     google.maps.ControlPosition.TOP_CENTER,
-                                     :RC
-                                     google.maps.ControlPosition.RIGHT_CENTER,
-                                     :RT
-                                     google.maps.ControlPosition.RIGHT_TOP,
-                                     :RB
-                                     google.maps.ControlPosition.RIGHT_BOTTOM}
-                  maps         (.. js/google -maps)
-                  Map          (.-Map maps)
-                  Event        (.-event maps)
-                  LatLng       (.-LatLng maps)
-                  Marker       (.-Marker maps)
-                  Polyline     (.-Polyline maps)
-                  Polygon      (.-Polygon maps)
-                  InfoWindow   (.-InfoWindow maps)
-                  iw           (InfoWindow. (clj->js {}))
-                  LatLngBounds (.-LatLngBounds maps)
-                  lat-lng      #(LatLng. (js/parseFloat %1) (js/parseFloat %2))
-                  opts         (cell= (let [{:keys [lat lng]} center]
-                                        (clj->js (merge {} map-opts {:center (lat-lng lat lng)}))))
-                  imap         (Map. elem @opts)
-                  map-ctrls    (.-controls imap)
-                  bounds       (cell= (with-let [b (LatLngBounds.)]
-                                        (doseq [{:keys [lat lng]} markers]
-                                          (.extend b (lat-lng lat lng)))))]
+            (let [maps           (.. js/google -maps)
+                  Map            (.-Map maps)
+                  Event          (.-event maps)
+                  LatLng         (.-LatLng maps)
+                  Marker         (.-Marker maps)
+                  Polyline       (.-Polyline maps)
+                  Polygon        (.-Polygon maps)
+                  Circle         (.-Circle maps)
+                  InfoWindow     (.-InfoWindow maps)
+                  iw             (InfoWindow. (clj->js {}))
+                  LatLngBounds   (.-LatLngBounds maps)
+                  lat-lng        #(LatLng. (js/parseFloat %1) (js/parseFloat %2))
+                  opts           (cell= (let [{:keys [lat lng]} center]
+                                          (clj->js (merge {} map-opts {:center (lat-lng lat lng)}))))
+                  imap           (Map. elem @opts)
+                  map-ctrls      (.-controls imap)
+                  bounds         (cell= (with-let [b (LatLngBounds.)]
+                                          (doseq [{:keys [lat lng]} markers]
+                                            (.extend b (lat-lng lat lng)))))
+                  cp             {:TL google.maps.ControlPosition.TOP_LEFT, :BC google.maps.ControlPosition.BOTTOM_CENTER, :LC google.maps.ControlPosition.LEFT_CENTER,
+                                  :BL google.maps.ControlPosition.BOTTOM_LEFT, :LB google.maps.ControlPosition.LEFT_BOTTOM, :BR google.maps.ControlPosition.BOTTOM_RIGHT,
+                                  :TR google.maps.ControlPosition.TOP_RIGHT, :LT google.maps.ControlPosition.LEFT_TOP, :TC google.maps.ControlPosition.TOP_CENTER,
+                                  :RC google.maps.ControlPosition.RIGHT_CENTER, :RT google.maps.ControlPosition.RIGHT_TOP, :RB google.maps.ControlPosition.RIGHT_BOTTOM}]
+
+              ;;;; Map Callbacks
               (doseq [x map-callbacks]
                 (let [evt (rm-pfx (name (key x)))
                       fun (val x)
                       wrp (fn [& args] (apply fun imap args)) ]
                   (.addListener Event imap evt wrp)))
+
+              ;;;;; Layers
               (mapv #(layer (key %) (val %) imap) layers)
+
+              ;;;;;; Controls
               (doseq [x controls]
                 (let [pos (:position x) ctrls (:controls x) ]
                   (.push
-                    (aget map-ctrls (pos control-positions))
+                    (aget map-ctrls (pos cp))
                     (div ctrls))))
+
+              ;;;;;; Polylines
               (cell-doseq [[i {:keys [path opts] :as pline}] (cell= (indexed polylines))]
                 (let [polyline  (Polyline. (clj->js {}))]
                   (doseq [x pln-callbacks]
@@ -173,10 +169,30 @@
                           fun (val x)
                           wrp (fn [& args] (apply fun imap polyline pline args))]
                       (.addListener Event polyline evt wrp)))
-                  (cell= (let [map  (when path imap)
-                               path (if path (mapv #(lat-lng (:lat %) (:lng %)) path) [])
-                               opt  (clj->js (merge {} opts {:map map :path path}))]
-                           (.setOptions polyline opt)))))
+                  (cell=
+                    ((~(partial delay-until visible?)
+                      #(let [map  (when path imap)
+                             path (if path (mapv (fn [p] (lat-lng (:lat p) (:lng p))) path) [])
+                             opt  (clj->js (merge {} opts {:map map :path path}))]
+                        (.setOptions polyline opt)))))))
+
+              ;;;;;;; Circles
+              (cell-doseq [[i {:keys [opts] :as circ}] (cell= (indexed circles))]
+                (let [circle (Circle. (clj->js {}))
+                      _      (cell= (.log js/console (clj->js circ)))]
+                  (doseq [x cir-callbacks]
+                    (let [evt (rm-pfx (name (key x)))
+                          fun (val x)
+                          wrp (fn [& args] (apply fun imap circle circ args))]
+                      (.addListener Event circle evt wrp)))
+                  (cell=
+                    ((~(partial delay-until visible?)
+                      #(let [map  imap
+                             opt  (clj->js (merge {} opts {:map map}))]
+                      (.setOptions circle opt)))))))
+
+
+              ;;;;;;; Polygons
               (cell-doseq [[i {:keys [path opts] :as pgon}] (cell= (indexed polygons))]
                 (let [ polygon (Polygon. (clj->js {}))]
                   (doseq [x pgn-callbacks]
@@ -184,15 +200,22 @@
                           fun (val x)
                           wrp (fn [& args] (apply fun imap polygon pgon args))]
                       (.addListener Event polygon evt wrp)))
-                  (cell= (let [map  (when path imap)
-                               path (if path (mapv #(lat-lng (:lat %) (:lng %)) path) [])
-                               opt  (clj->js (merge {} opts {:map map :path path}))]
-                           (.setOptions polygon opt)))))
-              (cell= (.setOptions imap opts))
-              (cell= (when (seq markers) (.trigger Event imap "resize")))
-              (cell= (when (and fit-pins (seq markers))
+                  (cell=
+                    ((~(partial delay-until visible?)
+                      #(let [map  (when path imap)
+                             path (if path (mapv (fn [p] (lat-lng (:lat p) (:lng p))) path) [])
+                             opt  (clj->js (merge {} opts {:map map :path path}))]
+                      (.setOptions polygon opt)))))))
+
+              ;;;;;; Options
+              (cell= ((~(partial delay-until visible?) #(.setOptions imap opts))))
+
+              ;;;;;; fit-pins
+              (cell= (when (and (seq markers) fit-pins)
                        ((~(partial delay-until visible?)
                          #(.fitBounds imap bounds)))))
+
+              ;;;;; Markers
               (cell-doseq [[i {:keys [lat lng info opts] :as pin}] (cell= (indexed markers))]
                 (let [marker  (Marker. (clj->js {}))
                       info    (cell= info)]
@@ -206,8 +229,9 @@
                       (when @info
                         (.setContent iw @info)
                         (.open iw imap marker))))
-                  (cell= (let [map (when lat imap)
-                               pos (when lat (lat-lng lat lng))
-                               opt (clj->js (merge {} opts {:map map :position pos}))]
-                           (.close iw)
-                           (.setOptions marker opt))))))))))))
+                  (cell= ((~(partial delay-until visible?)
+                          #(let [map (when lat imap)
+                                pos (when lat (lat-lng lat lng))
+                                opt (clj->js (merge {} opts {:map map :position pos}))]
+                            (.close iw)
+                            (.setOptions marker opt))))))))))))))

--- a/src/hoplon/google/jsapi/maps.cljs.hl
+++ b/src/hoplon/google/jsapi/maps.cljs.hl
@@ -19,7 +19,7 @@
     :else x))
 
 (defc  maps-version "3")
-(defc  maps-options {:other_params "sensor=false&libraries=geometry"})
+(defc  maps-options {:other_params "libraries=geometry"})
 
 (def ensure-maps
   (queued
@@ -146,13 +146,13 @@
                   InfoWindow   (.-InfoWindow maps)
                   LatLngBounds (.-LatLngBounds maps)
                   lat-lng      #(LatLng. (js/parseFloat %1) (js/parseFloat %2))
-                  opts         (cell= (let [{:keys [lat lon]} center]
-                                        (clj->js (merge {} map-opts {:center (lat-lng lat lon)}))))
+                  opts         (cell= (let [{:keys [lat lng]} center]
+                                        (clj->js (merge {} map-opts {:center (lat-lng lat lng)}))))
                   imap         (Map. elem @opts)
                   map-ctrls    (.-controls imap)
                   bounds       (cell= (with-let [b (LatLngBounds.)]
-                                        (doseq [{:keys [lat lon]} markers]
-                                          (.extend b (lat-lng lat lon)))))]
+                                        (doseq [{:keys [lat lng]} markers]
+                                          (.extend b (lat-lng lat lng)))))]
               (doseq [x map-callbacks]
                 (let [evt (rm-pfx (name (key x))) 
                       fun (val x)
@@ -191,7 +191,7 @@
               (cell= (when (and fit-pins (seq markers))
                        ((~(partial delay-until visible?)
                          #(.fitBounds imap bounds)))))
-              (cell-doseq [[i {:keys [lat lon info opts] :as pin}] (cell= (indexed markers))]
+              (cell-doseq [[i {:keys [lat lng info opts] :as pin}] (cell= (indexed markers))]
                 (let [marker  (Marker. (clj->js {}))
                       iwindow (InfoWindow. (clj->js {}))]
                   (doseq [x pin-callbacks]
@@ -204,7 +204,7 @@
                       (when @info (.open iwindow imap marker))))
                   (cell= (doto iwindow (.setContent (dom2str info)) .close))
                   (cell= (let [map (when lat imap)
-                               pos (when lat (lat-lng lat lon))
+                               pos (when lat (lat-lng lat lng))
                                opt (clj->js (merge {} opts {:map map :position pos}))]
                            (.close iwindow)
                            (.setOptions marker opt))))))))))))

--- a/src/hoplon/google/jsapi/maps.cljs.hl
+++ b/src/hoplon/google/jsapi/maps.cljs.hl
@@ -19,7 +19,7 @@
     :else x))
 
 (defc  maps-version "3")
-(defc  maps-options {:other_params "sensor=false&libraries=geometry"})
+(defc  maps-options {:other_params "libraries=geometry"})
 
 (def ensure-maps
   (queued
@@ -49,7 +49,7 @@
     (into
       []
       (map
-        #(assoc {} :lat (.lat (clj->js %)) :lon (.lng (clj->js %)))
+        #(assoc {} :lat (.lat (clj->js %)) :lng (.lng (clj->js %)))
         points))))
 
 (defn point-in-polygon [point path]
@@ -58,8 +58,8 @@
         Polygon           (.-Polygon maps)
         poly-lib          (.-poly (.-geometry maps))
         lat-lng           #(LatLng. (js/parseFloat %1) (js/parseFloat %2))
-        gon               (Polygon. (clj->js {:path (mapv #(lat-lng (:lat %) (:lon %)) path)})) 
-        pnt               (lat-lng (:lat point) (:lon point))
+        gon               (Polygon. (clj->js {:path (mapv #(lat-lng (:lat %) (:lng %)) path)}))
+        pnt               (lat-lng (:lat point) (:lng point))
         res               (.containsLocation poly-lib pnt gon)]
     res))
 
@@ -88,7 +88,7 @@
 
 (defelem google-map-control
   [attr kids]
-  {:position (keyword (:position attr)) :control kids})
+  (assoc {} :position (keyword (:position attr)) :controls kids))
 
 (defelem google-map [attr kids]
   (with-let [elem       (div (select-keys attr (keys (filter #(not= "hoplon.google.jsapi.maps" (namespace (key %))) attr))))]
@@ -99,6 +99,7 @@
           markers       (:hoplon.google.jsapi.maps/markers attr)
           polylines     (:hoplon.google.jsapi.maps/polylines attr)
           polygons      (:hoplon.google.jsapi.maps/polygons attr)
+          controls      (:hoplon.google.jsapi.maps/controls attr)
           mkfilter      #(fn [[x _]]
                            (let [ns (namespace x) nm (name x)]
                              (and (= "hoplon.google.jsapi.maps" ns)
@@ -144,67 +145,69 @@
                   Polyline     (.-Polyline maps)
                   Polygon      (.-Polygon maps)
                   InfoWindow   (.-InfoWindow maps)
+                  iw           (InfoWindow. (clj->js {}))
                   LatLngBounds (.-LatLngBounds maps)
                   lat-lng      #(LatLng. (js/parseFloat %1) (js/parseFloat %2))
-                  opts         (cell= (let [{:keys [lat lon]} center]
-                                        (clj->js (merge {} map-opts {:center (lat-lng lat lon)}))))
+                  opts         (cell= (let [{:keys [lat lng]} center]
+                                        (clj->js (merge {} map-opts {:center (lat-lng lat lng)}))))
                   imap         (Map. elem @opts)
                   map-ctrls    (.-controls imap)
                   bounds       (cell= (with-let [b (LatLngBounds.)]
-                                        (doseq [{:keys [lat lon]} markers]
-                                          (.extend b (lat-lng lat lon)))))]
+                                        (doseq [{:keys [lat lng]} markers]
+                                          (.extend b (lat-lng lat lng)))))]
               (doseq [x map-callbacks]
-                (let [evt (rm-pfx (name (key x))) 
+                (let [evt (rm-pfx (name (key x)))
                       fun (val x)
                       wrp (fn [& args] (apply fun imap args)) ]
                   (.addListener Event imap evt wrp)))
               (mapv #(layer (key %) (val %) imap) layers)
-              (doseq [x kids]
-                (let [pos (:position x) ctrls (:control x)]
-                  (doseq [ctrl ctrls]
-                    (.push
-                      (aget map-ctrls (pos control-positions))
-                      (div ctrl)))))
+              (doseq [x controls]
+                (let [pos (:position x) ctrls (:controls x) ]
+                  (.push
+                    (aget map-ctrls (pos control-positions))
+                    (div ctrls))))
               (cell-doseq [[i {:keys [path opts] :as pline}] (cell= (indexed polylines))]
                 (let [polyline  (Polyline. (clj->js {}))]
                   (doseq [x pln-callbacks]
-                    (let [evt (rm-pfx (name (key x))) 
+                    (let [evt (rm-pfx (name (key x)))
                           fun (val x)
                           wrp (fn [& args] (apply fun imap polyline pline args))]
                       (.addListener Event polyline evt wrp)))
                   (cell= (let [map  (when path imap)
-                               path (if path (mapv #(lat-lng (:lat %) (:lon %)) path) [])
+                               path (if path (mapv #(lat-lng (:lat %) (:lng %)) path) [])
                                opt  (clj->js (merge {} opts {:map map :path path}))]
                            (.setOptions polyline opt)))))
               (cell-doseq [[i {:keys [path opts] :as pgon}] (cell= (indexed polygons))]
                 (let [ polygon (Polygon. (clj->js {}))]
                   (doseq [x pgn-callbacks]
-                    (let [evt (rm-pfx (name (key x))) 
+                    (let [evt (rm-pfx (name (key x)))
                           fun (val x)
                           wrp (fn [& args] (apply fun imap polygon pgon args))]
                       (.addListener Event polygon evt wrp)))
                   (cell= (let [map  (when path imap)
-                               path (if path (mapv #(lat-lng (:lat %) (:lon %)) path) [])
+                               path (if path (mapv #(lat-lng (:lat %) (:lng %)) path) [])
                                opt  (clj->js (merge {} opts {:map map :path path}))]
                            (.setOptions polygon opt)))))
               (cell= (.setOptions imap opts))
+              (cell= (when (seq markers) (.trigger Event imap "resize")))
               (cell= (when (and fit-pins (seq markers))
                        ((~(partial delay-until visible?)
                          #(.fitBounds imap bounds)))))
-              (cell-doseq [[i {:keys [lat lon info opts] :as pin}] (cell= (indexed markers))]
+              (cell-doseq [[i {:keys [lat lng info opts] :as pin}] (cell= (indexed markers))]
                 (let [marker  (Marker. (clj->js {}))
-                      iwindow (InfoWindow. (clj->js {}))]
+                      info    (cell= info)]
                   (doseq [x pin-callbacks]
-                    (let [evt  (rm-pfx (name (key x))) 
+                    (let [evt  (rm-pfx (name (key x)))
                           fun  (val x)
-                          wrp  (fn [& args] (apply fun imap marker iwindow @pin args))]
+                          wrp  (fn [& args] (apply fun imap marker iw @pin args))]
                       (.addListener Event marker evt wrp)))
                   (.addListener Event marker "click"
                     (fn []
-                      (when @info (.open iwindow imap marker))))
-                  (cell= (doto iwindow (.setContent (dom2str info)) .close))
+                      (when @info
+                        (.setContent iw @info)
+                        (.open iw imap marker))))
                   (cell= (let [map (when lat imap)
-                               pos (when lat (lat-lng lat lon))
+                               pos (when lat (lat-lng lat lng))
                                opt (clj->js (merge {} opts {:map map :position pos}))]
-                           (.close iwindow)
+                           (.close iw)
                            (.setOptions marker opt))))))))))))

--- a/src/hoplon/google/jsapi/maps.cljs.hl
+++ b/src/hoplon/google/jsapi/maps.cljs.hl
@@ -49,7 +49,7 @@
     (into
       []
       (map
-        #(assoc {} :lat (.lat (clj->js %)) :lon (.lng (clj->js %)))
+        #(assoc {} :lat (.lat (clj->js %)) :lng (.lng (clj->js %)))
         points))))
 
 (defn point-in-polygon [point path]
@@ -58,8 +58,8 @@
         Polygon           (.-Polygon maps)
         poly-lib          (.-poly (.-geometry maps))
         lat-lng           #(LatLng. (js/parseFloat %1) (js/parseFloat %2))
-        gon               (Polygon. (clj->js {:path (mapv #(lat-lng (:lat %) (:lon %)) path)})) 
-        pnt               (lat-lng (:lat point) (:lon point))
+        gon               (Polygon. (clj->js {:path (mapv #(lat-lng (:lat %) (:lng %)) path)})) 
+        pnt               (lat-lng (:lat point) (:lng point))
         res               (.containsLocation poly-lib pnt gon)]
     res))
 
@@ -173,7 +173,7 @@
                           wrp (fn [& args] (apply fun imap polyline pline args))]
                       (.addListener Event polyline evt wrp)))
                   (cell= (let [map  (when path imap)
-                               path (if path (mapv #(lat-lng (:lat %) (:lon %)) path) [])
+                               path (if path (mapv #(lat-lng (:lat %) (:lng %)) path) [])
                                opt  (clj->js (merge {} opts {:map map :path path}))]
                            (.setOptions polyline opt)))))
               (cell-doseq [[i {:keys [path opts] :as pgon}] (cell= (indexed polygons))]
@@ -184,7 +184,7 @@
                           wrp (fn [& args] (apply fun imap polygon pgon args))]
                       (.addListener Event polygon evt wrp)))
                   (cell= (let [map  (when path imap)
-                               path (if path (mapv #(lat-lng (:lat %) (:lon %)) path) [])
+                               path (if path (mapv #(lat-lng (:lat %) (:lng %)) path) [])
                                opt  (clj->js (merge {} opts {:map map :path path}))]
                            (.setOptions polygon opt)))))
               (cell= (.setOptions imap opts))


### PR DESCRIPTION
data returned from google (e.g. geocode requests) use :lng as the key for longitude. this makes it very inconvenient to use google maps component with google data as it requires adding a :lon key for each marker, polyline, layer, etc.
